### PR TITLE
added not-implemented Spectrum1D

### DIFF
--- a/astrospec/__init__.py
+++ b/astrospec/__init__.py
@@ -4,6 +4,15 @@
 This is an Astropy affiliated package.
 """
 
+# Elevate objects to the package level
+from spectrum import Spectrum1D
+
+__all__ = ['Spectrum1D']
+
+
+
+
+
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------

--- a/astrospec/__init__.py
+++ b/astrospec/__init__.py
@@ -5,7 +5,7 @@ This is an Astropy affiliated package.
 """
 
 # Elevate objects to the package level
-from spectrum import Spectrum1D
+from .spectrum import Spectrum1D
 
 __all__ = ['Spectrum1D']
 

--- a/astrospec/spectrum.py
+++ b/astrospec/spectrum.py
@@ -1,0 +1,15 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Module for the Spectrum object and related functionality."""
+
+from astropy.nddata import NDData
+
+
+class SpectrumError(Exception):
+    """Primary exception specific to the Spectrum object."""
+
+
+class Spectrum1D:
+    """A spectrum object wraps an Astropy NDData array plus metadata."""
+
+    def __init__(self, data=None, wcs=None, filepath=None, **kwargs):
+        """Initialize via either an already existing data array or from a file."""

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,7 @@ Astrospec has the following requirements:
 
 One easy way to get these dependencies is to install a python distribution like `anaconda <http://continuum.io/>`_.
 
-Installing psfsubtraction
+Installing astrospec
 =========================
 
 .. comment NOT on PIPY yet
@@ -22,7 +22,7 @@ Installing psfsubtraction
 
    To install ccdproc with `pip <http://www.pip-installer.org/en/latest/>`_, simply run::
 
-       pip install --no-deps psfsubtraction
+       pip install --no-deps astrospec
 
    .. note::
 
@@ -43,7 +43,7 @@ At this early stage of development not source packages are available.
 
 .. comment Not on PiPy yet
    The latest stable source package for ccdproc can be `downloaded here
-   <https://pypi.python.org/pypi/psfsubtraction>`_.
+   <https://pypi.python.org/pypi/astrospec>`_.
 
 Development repository
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -56,19 +56,18 @@ using this command::
 Building and Installing
 -----------------------
 
-To build psfsubtraction (from the root of the source tree)::
+To build astrospec (from the root of the source tree)::
 
     python setup.py build
 
-To install psfsubtraction (from the root of the source tree)::
+To install astrospec (from the root of the source tree)::
 
     python setup.py install
 
 Testing a source code build of ccdproc
 --------------------------------------
 
-The easiest way to test that your psfsubtraction built correctly (without
+The easiest way to test that your astrospec built correctly (without
 installing it) is to run this from the root of the source tree::
 
     python setup.py test
-


### PR DESCRIPTION
I've simply created the place for use start start building up the Spectrum1D object. The **init** method isn't implemented.
