### PR TITLE
Proof of concept implementation of a Spectrum1D based on quantities

### DIFF
--- a/astrospec/__init__.py
+++ b/astrospec/__init__.py
@@ -12,5 +12,4 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
-    pass
-    #from spectrum import Spectrum1D
+    from spectrum import Spectrum1D

--- a/astrospec/spectrum1d.py
+++ b/astrospec/spectrum1d.py
@@ -1,0 +1,65 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+
+from astropy.nddata import support_nddata
+from astropy.utils.metadata import MetaData
+from astropy.units.quantity import Quantity
+
+from warnings import warn
+
+from .wcs import WCSTable
+
+class Spectrum1D(object):
+    meta = MetaData()
+
+    @support_nddata
+    def __init__(self, data, dispersion=None, dispersion_unit=None,
+                 uncertainty=None, mask=None, meta=None, unit=None,
+                 flags=None):
+
+    self.meta = meta
+
+    data = Quantity(data, unit)
+
+    if mask is None:
+        self.data = data
+    else:
+        self.data = np.ma.asanyarray(data)
+        self.data[mask] = np.ma.masked
+
+    if wcs is None:
+        if dispersion is None:
+            raise ValueError('Specify dispersion or WCS, but not both.')
+        else:
+            if len(self.data) != len(self.dispersion):
+                raise ValueError('Data and dispersion need to have same number of elements.')
+
+            self.wcs = WCSTable(dispersion, dispersion_unit)
+    else:
+        self.wcs = wcs
+
+
+    # For now, just save it. We can do stuff with that later.
+    self.uncertainty = uncertainty
+    self.flags = flags
+
+    # Two examples how we can interact with a WCS
+    # If we do this, we have to specify that all WCS are slicable and have a shift_rv.
+    def shift_rv(self, rv):
+        '''Shift spectrum by rv
+
+        Parameters
+        ----------
+        rv : `~astropy.units.quantity.Quantity`
+            radial velocity (positive value will red-shift the spectrum, negative
+            value will blue-shift the spectrum)
+        '''
+        self.wcs.shift_rv(rv)
+
+    def slice_dispersion(self, x0, x1):
+        ind = self.wcs.between(x0, x1)
+        flags = None if self.flags is None else self.flags[ind]
+        uncertainty = None if self.uncertainty is None else self.uncertainty[ind]
+
+        return self.__class__(self.data[ind], self.wcs[ind], meta=self.meta,
+                              flags=flags, uncertainty=uncertainty)

--- a/astrospec/wcs.py
+++ b/astrospec/wcs.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+
+from astropy.units.quantity import Quantity
+from astropy.constants import c as c_light
+import astropy.units as u
+
+class WCSTable(Quantity):
+
+    def between(x0, x1):
+        '''
+        Could be more clever.
+        Currently, this is only a proof of concept.
+        For now, it only works if the WCS table and the x0, x1 have
+        compatible dimesiones, e.g. dimension of lengths.
+        Using spectral equivalencies, we could have a WCS in nm,
+        but pass x0, x1 in Hz or keV and it would work.
+        '''
+        return (self >= x0) & (self < x1)
+
+    def shift_rv(self, rv):
+        '''Shift spectrum by rv
+
+        Parameters
+        ----------
+        rv : `~astropy.units.quantity.Quantity`
+            radial velocity (positive value will red-shift the spectrum, negative
+            value will blue-shift the spectrum)
+        '''
+        self[:] = (self.to(u.m, equivalencies=u.spectral()) * (
+                1.*u.dimensionless_unscaled+rv/const.c)).to(
+                self.unit, equivalencies=u.spectral())


### PR DESCRIPTION
This code is untested (Travis will probably fail) and there is no documentation yet. 
I just want to put it up here so that we can discuss it as a proof of concept.
If I did everything right (which I certainly not yet) then each spectrum will have a .data and a wcs.
The .data could be a plain numpy array (best for speed), a masked array or an astropy quantity, which is not quite as fast as a plain numpy array, but is helps a lot for things like

```
import astropy.units as u
s = Sepctrum(data * u.Angstroem, ...)
OVII_triplet = s.between(0.5 * u.keV, 0.7 * u.keV)
```

@glentner : Please see what you think. 
I find it easier to discuss such design decisions with a reference implementation, than on the wiki, to please have a look and tell me if I should work this out in detail / if you are totally opposed / if you suggest modifications...
