### PR TITLE
Fix coverage run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
     include:
 
         # Do a coverage test in Python 3.
-        - python: 3.5
+        - python: 2.7
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,12 +92,9 @@ install:
     # well as at the start of the install section or in the before_install
     # section if they are needed before setting up conda) to install any
     # other dependencies.
-    - pip install coverage
 
 script:
    - python setup.py $SETUP_CMD
-   - coverage run --source=astrospec setup.py $SETUP_CMD
-
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,4 +100,4 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='astrospec/tests/coveragerc'; fi

--- a/astrospec/tests/coveragerc
+++ b/astrospec/tests/coveragerc
@@ -1,16 +1,16 @@
 [run]
-source = {astrospec}
+source = astrospec
 omit =
-   {astrospec}/_astropy_init*
-   {astrospec}/conftest*
-   {astrospec}/cython_version*
-   {astrospec}/setup_package*
-   {astrospec}/*/setup_package*
-   {astrospec}/*/*/setup_package*
-   {astrospec}/tests/*
-   {astrospec}/*/tests/*
-   {astrospec}/*/*/tests/*
-   {astrospec}/version*
+   astrospec/_astropy_init*
+   astrospec/conftest*
+   astrospec/cython_version*
+   astrospec/setup_package*
+   astrospec/*/setup_package*
+   astrospec/*/*/setup_package*
+   astrospec/tests/*
+   astrospec/*/tests/*
+   astrospec/*/*/tests/*
+   astrospec/version*
 
 [report]
 exclude_lines =

--- a/astrospec/tests/coveragerc
+++ b/astrospec/tests/coveragerc
@@ -1,16 +1,16 @@
 [run]
-source = {packagename}
+source = {astrospec}
 omit =
-   {packagename}/_astropy_init*
-   {packagename}/conftest*
-   {packagename}/cython_version*
-   {packagename}/setup_package*
-   {packagename}/*/setup_package*
-   {packagename}/*/*/setup_package*
-   {packagename}/tests/*
-   {packagename}/*/tests/*
-   {packagename}/*/*/tests/*
-   {packagename}/version*
+   {astrospec}/_astropy_init*
+   {astrospec}/conftest*
+   {astrospec}/cython_version*
+   {astrospec}/setup_package*
+   {astrospec}/*/setup_package*
+   {astrospec}/*/*/setup_package*
+   {astrospec}/tests/*
+   {astrospec}/*/tests/*
+   {astrospec}/*/*/tests/*
+   {astrospec}/version*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
the previous setup accidentally run the tests twice, leading to incorrect coverage results.

I was not careful in enough in merging #7. #7 added a coverage run to _each_ test run, when in fact it's sufficient to run one of the test instances for coverage. (I don't think we need to list that as a dependency here either - astropy should have done that already).

I noticed that the coverage result is far too low. Running it locally, I find > 80%. Debugging that I noticed that all tests are run twice on Travis. Fixing this issue hopefully solves the incorrect coverage (I assume that generating the report twice in the same file name just screws up the numbers).

So, we'll need a careful look at the Travis log to make such this is now all right before we merge this.
